### PR TITLE
Update regex_phone#_lookup.py

### DIFF
--- a/Beginner Projects/Automation and data manipulation/regex_phone#_lookup.py
+++ b/Beginner Projects/Automation and data manipulation/regex_phone#_lookup.py
@@ -6,7 +6,7 @@ import re
 #"\d" is a digit, 
 # "{3}" and "{4}" is the number of digits in a row
 #""
-phone_num_regex = r'\d{3}-\d{3}-\d{4}'
+phone_num_regex = r'\d{3}-\S{3}-\S{4}'
 mo= re.compile(phone_num_regex)
 
 #example strings to search through


### PR DESCRIPTION
changed the expression in order to also catch phone numbers that are written as "555-DOC-HELP" instead of only using numbers.

## Summary by Sourcery

Enhancements:
- Replace digit-only quantifiers in the regex with non-whitespace matches to allow alphanumeric segments in phone numbers